### PR TITLE
Fix missing second-last label and axis line

### DIFF
--- a/examples/broken.html
+++ b/examples/broken.html
@@ -1,0 +1,12 @@
+<html><head>
+    <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.0/jquery.min.js"></script>
+    <script type="text/javascript" src="raphael.min.js"></script>
+    <script type="text/javascript" src="../compiled/charts.js"></script>
+    <script type="text/javascript" src="broken.js"></script>
+  </head>
+	<body>
+		<div id="container">
+			<div class="app-1col" id="chart1" style="width: 900px; height: 300px; padding: 20px; margin-top:20px; margin-bottom:20px;"></div>
+		</div>
+	</body>
+</html>

--- a/examples/broken.js
+++ b/examples/broken.js
@@ -1,0 +1,45 @@
+$(document).ready(function() {
+    var monthly_sales = [
+    [new Date("2012-09-01T01:00:00+01:00"), 1486],
+    [new Date("2012-10-01T01:00:00+01:00"), 952],
+    [new Date("2012-11-01T00:00:00+00:00"), 2461],
+    [new Date("2012-12-01T00:00:00+00:00"), 631],
+    [new Date("2013-01-01T00:00:00+00:00"), 3644],
+    [new Date("2013-02-01T00:00:00+00:00"), 0],
+    [new Date("2013-03-01T00:00:00+00:00"), 0],
+    [new Date("2013-04-01T01:00:00+01:00"), 0],
+    [new Date("2013-05-01T01:00:00+01:00"), 0],
+    [new Date("2013-06-01T01:00:00+01:00"), 0],
+    [new Date("2013-07-01T01:00:00+01:00"), 0],
+    ]
+    var chart1 = new Charts.LineChart('chart1', {
+      show_grid: true,
+      show_y_labels: true,
+      show_x_labels:true,
+      label_max: false,
+      label_min: false,
+      multi_axis: false,
+      max_y_labels: 9,
+      max_x_labels: 48,
+      x_padding: 55,
+      y_padding:40,
+      x_label_size: 13,
+      label_format: "%m/%Y",
+      y_axis_scale: [0, 8000]
+    });
+
+    chart1.add_line({
+      data: monthly_sales,
+      options: {
+        line_color: "#16728c",
+        dot_color: "#16a2cb",
+        dot_stroke_size: 1,
+        dot_stroke_color: "#16728c",
+        area_opacity: 0.3,
+        dot_size: 5,
+        line_width: 1,
+        smoothing: 0
+      }
+    });
+    chart1.draw();
+})

--- a/src/coffeescript/charts/line_chart.coffee
+++ b/src/coffeescript/charts/line_chart.coffee
@@ -287,7 +287,7 @@ class LineChart extends BaseChart
     label_coordinates.push points[last].x
     return if max_labels < 3
 
-    len = points.length-2
+    len = points.length-1
     step_size  = len / (max_labels-1)
 
     # when irrational


### PR DESCRIPTION
Hey!

I was having an issue with a missing label and axis line and have narrowed it down to this line.
This is my JS:

``` javascript
    var monthly_sales = [
    [new Date("2012-09-01T01:00:00+01:00"), 1486],
    [new Date("2012-10-01T01:00:00+01:00"), 952],
    [new Date("2012-11-01T00:00:00+00:00"), 2461],
    [new Date("2012-12-01T00:00:00+00:00"), 631],
    [new Date("2013-01-01T00:00:00+00:00"), 3644],
    [new Date("2013-02-01T00:00:00+00:00"), 0],
    [new Date("2013-03-01T00:00:00+00:00"), 0],
    [new Date("2013-04-01T01:00:00+01:00"), 0],
    [new Date("2013-05-01T01:00:00+01:00"), 0],
    [new Date("2013-06-01T01:00:00+01:00"), 0],
    [new Date("2013-07-01T01:00:00+01:00"), 0],
    ]
    var chart1 = new Charts.LineChart('chart1', {
      show_grid: true,
      show_y_labels: true,
      show_x_labels:true,
      label_max: false,
      label_min: false,
      multi_axis: false,
      max_y_labels: 9,
      max_x_labels: 48,
      x_padding: 55,
      y_padding:40,
      x_label_size: 13,
      label_format: "%m/%Y",
      y_axis_scale: [0, 8000]
    });

    chart1.add_line({
      data: monthly_sales,
      options: {
        line_color: "#16728c",
        dot_color: "#16a2cb",
        dot_stroke_size: 1,
        dot_stroke_color: "#16728c",
        area_opacity: 0.3,
        dot_size: 5,
        line_width: 1,
        smoothing: 0
      }
    });
    chart1.draw();
```

Before and after pictures are attached!

Cheers,
W
![screen shot 2013-08-08 at 14 15 59](https://f.cloud.github.com/assets/351076/931442/81c9f8ae-002d-11e3-9fcd-974fa80135c7.png)
![screen shot 2013-08-08 at 14 16 29](https://f.cloud.github.com/assets/351076/931443/81f6230c-002d-11e3-97cd-f90ccd728488.png)
